### PR TITLE
Support custom task names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+- Support custom task names
+
+## v0.1.0
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ bundle exec rake admin:special
 
 ```ruby
 class ObscureClassNameTask do
-  include OopsARake::Task.with_name("custom_name")
+  include OopsARake::Task.with_options(name: "custom_name")
 
   def call
     puts "Hello"

--- a/README.md
+++ b/README.md
@@ -110,6 +110,24 @@ Invocation:
 bundle exec rake admin:special
 ```
 
+### Task with a custom name
+
+```ruby
+class ObscureClassNameTask do
+  include OopsARake::Task.with_name("custom_name")
+
+  def call
+    puts "Hello"
+  end
+end
+```
+
+Invocation:
+
+```sh
+bundle exec rake custom_name
+```
+
 ## Motivation
 
 Rake is an omnipresent tool in the Ruby world. It has some drawbacks – the main

--- a/lib/oops_a_rake/registry.rb
+++ b/lib/oops_a_rake/registry.rb
@@ -6,9 +6,7 @@ module OopsARake
     @tasks = {}
 
     def self.register(task_class)
-      task_name = task_class.name.underscore.gsub("/", ":").delete_suffix("_task")
-
-      task = Rake::Task.define_task(task_name) do |_, args|
+      task = Rake::Task.define_task(task_class.task_name) do |_, args|
         task_class.new.call(*args)
       end
 

--- a/lib/oops_a_rake/task.rb
+++ b/lib/oops_a_rake/task.rb
@@ -7,13 +7,13 @@ module OopsARake
       Registry::register(klass)
     end
 
-    def self.with_name(custom_task_name)
-      module_name = "#{custom_task_name.gsub(":", "_").classify}ClassMethods"
+    def self.with_options(name:)
+      module_name = "#{name.gsub(":", "_").classify}ClassMethods"
       mod = const_set(module_name, Module.new)
 
       mod.define_singleton_method(:included) do |klass|
-        klass.extend(OopsARake::Task::ClassMethods)
-        klass.define_singleton_method(:task_name) { custom_task_name }
+        klass.define_singleton_method(:task_name) { name }
+        klass.extend(ClassMethods)
         Registry::register(klass)
       end
 
@@ -22,7 +22,11 @@ module OopsARake
 
     module ClassMethods
       def task_name
-        name.underscore.gsub("/", ":").delete_suffix("_task")
+        if defined?(super)
+          super
+        else
+          name.underscore.gsub("/", ":").delete_suffix("_task")
+        end
       end
 
       def description(description)

--- a/lib/oops_a_rake/task.rb
+++ b/lib/oops_a_rake/task.rb
@@ -3,11 +3,28 @@ require_relative "registry"
 module OopsARake
   module Task
     def self.included(klass)
-      Registry::register(klass)
       klass.extend(ClassMethods)
+      Registry::register(klass)
+    end
+
+    def self.with_name(custom_task_name)
+      module_name = "#{custom_task_name.gsub(":", "_").classify}ClassMethods"
+      mod = const_set(module_name, Module.new)
+
+      mod.define_singleton_method(:included) do |klass|
+        klass.extend(OopsARake::Task::ClassMethods)
+        klass.define_singleton_method(:task_name) { custom_task_name }
+        Registry::register(klass)
+      end
+
+      mod
     end
 
     module ClassMethods
+      def task_name
+        name.underscore.gsub("/", ":").delete_suffix("_task")
+      end
+
       def description(description)
         task.comment = description
       end

--- a/spec/lib/oops_a_rake/task_spec.rb
+++ b/spec/lib/oops_a_rake/task_spec.rb
@@ -92,10 +92,10 @@ RSpec.describe OopsARake::Task do
     expect(Rake::Task["well_documented"].comment).to eq("Informative")
   end
 
-  describe "custom task name" do
+  describe "::with_options" do
     it "allows tasks to specify a custom name" do
       define_class("ObscureClassNameTask") do
-        include OopsARake::Task.with_name("clear_name")
+        include OopsARake::Task.with_options(name: "clear_name")
 
         def call
           puts "Hello"
@@ -108,7 +108,7 @@ RSpec.describe OopsARake::Task do
 
     it "provides access to the task name from the class" do
       define_class("ObscureClassNameTask") do
-        include OopsARake::Task.with_name("custom_name")
+        include OopsARake::Task.with_options(name: "custom_name")
 
         def call
         end
@@ -119,7 +119,7 @@ RSpec.describe OopsARake::Task do
 
     it "names the module" do
       define_class("ObscureClassNameTask") do
-        include OopsARake::Task.with_name("foo:bar_baz")
+        include OopsARake::Task.with_options(name: "foo:bar_baz")
 
         def call
         end

--- a/spec/lib/oops_a_rake/task_spec.rb
+++ b/spec/lib/oops_a_rake/task_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe OopsARake::Task do
     expect { Rake::Task["greeting"].invoke }.to output(/Hello/).to_stdout
   end
 
+  it "defines the task name on the class" do
+    define_class("GreetingTask") do
+      include OopsARake::Task
+
+      def call
+      end
+    end
+
+    expect(GreetingTask.task_name).to eq("greeting")
+  end
+
   it "supports tasks with arguments" do
     define_class("PersonalizedGreetingTask") do
       include OopsARake::Task
@@ -79,6 +90,44 @@ RSpec.describe OopsARake::Task do
     end
 
     expect(Rake::Task["well_documented"].comment).to eq("Informative")
+  end
+
+  describe "custom task name" do
+    it "allows tasks to specify a custom name" do
+      define_class("ObscureClassNameTask") do
+        include OopsARake::Task.with_name("clear_name")
+
+        def call
+          puts "Hello"
+        end
+      end
+
+      expect { Rake::Task["clear_name"].invoke }.to output(/Hello/).to_stdout
+      expect(Rake::Task.task_defined?("obscure_class_name")).to be false
+    end
+
+    it "provides access to the task name from the class" do
+      define_class("ObscureClassNameTask") do
+        include OopsARake::Task.with_name("custom_name")
+
+        def call
+        end
+      end
+
+      expect(ObscureClassNameTask.task_name).to eq("custom_name")
+    end
+
+    it "names the module" do
+      define_class("ObscureClassNameTask") do
+        include OopsARake::Task.with_name("foo:bar_baz")
+
+        def call
+        end
+      end
+
+      expect(ObscureClassNameTask.included_modules.map(&:to_s))
+        .to include("OopsARake::Task::FooBarBazClassMethods")
+    end
   end
 
   private


### PR DESCRIPTION
Resolves #2

## Example

```ruby
class ObscureClassNameTask do
  include OopsARake::Task.with_options(name: "custom_name")
  
  def call
    puts "Hello"
  end
end
```

Invocation:

```sh
bundle exec rake custom_name
```